### PR TITLE
Update split_one_chevs v2

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -60,7 +60,12 @@ config :teiserver, Teiserver,
   heartbeat_timeout: nil,
   enable_discord_bridge: false,
   enable_hailstorm: true,
-  accept_all_emails: true
+  accept_all_emails: true,
+
+  # The balance algorithm to use on the admin/matches/match/:id page
+  # It is purely used for analysis and not for actual games
+  # TODO move this into dropdown on admin/matches/match/:id page
+  analysis_balance_algorithm: "loser_picks"
 
 # Watch static and templates for browser reloading.
 config :teiserver, TeiserverWeb.Endpoint,

--- a/lib/teiserver/battle/balance/balance_types.ex
+++ b/lib/teiserver/battle/balance/balance_types.ex
@@ -10,7 +10,9 @@ defmodule Teiserver.Battle.Balance.BalanceTypes do
           names: [String.t()],
           ranks: [non_neg_integer()],
           group_rating: rating_value(),
-          count: non_neg_integer()
+          count: non_neg_integer(),
+          # Playtime hours + half spec time
+          rank_times: [non_neg_integer()]
         }
 
   @type group() :: %{

--- a/lib/teiserver/battle/balance/provisional_rating_lib.ex
+++ b/lib/teiserver/battle/balance/provisional_rating_lib.ex
@@ -1,0 +1,34 @@
+defmodule Teiserver.Battle.Balance.ProvisionalRatingLib do
+  @moduledoc """
+  This lib is only used by split_one_chevs balance algorithm
+  """
+  alias Teiserver.Battle.Balance.BalanceTypes, as: BT
+
+  @doc """
+  Users will have an adjusted rating that starts at 0 then converges to their OS as they accumulate chevron hours.
+  Chevron hours was chosen because there are visual indicators of when players achieve certain thresholds.
+  Chevron hours = playtime + spectime * 0.5
+  Once they hit their third chevron, adjusted rating will just equal OS.
+  """
+  @spec adjust_rating_from_hours([float()], [float()]) :: any()
+  def adjust_rating_from_hours(ratings, hours) do
+    target_hours = 15.0
+    zip_result = Enum.zip(ratings, hours)
+
+    Enum.map(zip_result, fn {user_rating, user_hours} ->
+      user_rating * min(1, user_hours / target_hours)
+    end)
+  end
+
+  @doc """
+  Function to assign provisional ratings to new users
+  """
+  @spec apply_provisional_ratings([BT.expanded_group()]) :: [BT.expanded_group()]
+  def apply_provisional_ratings(expanded_group) do
+    Enum.map(expanded_group, fn x ->
+      new_ratings = adjust_rating_from_hours(x.ratings, x.rank_times)
+      new_group_rating = Enum.sum(new_ratings)
+      Map.merge(x, %{ratings: new_ratings, group_rating: new_group_rating})
+    end)
+  end
+end

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -2,7 +2,7 @@ defmodule Teiserver.Battle.BalanceLib do
   @moduledoc """
   A set of functions related to balance, if you are looking to see how balance is implemented this is the place. Ratings are calculated via Teiserver.Game.MatchRatingLib and are used here. Please note ratings and balance are two very different things and complaints about imbalanced games need to be correct in addressing balance vs ratings.
   """
-  alias Teiserver.{Account, Config}
+  alias Teiserver.{Account, Config, CacheUser}
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Battle.Balance.BalanceTypes, as: BT
   alias Teiserver.Game.MatchRatingLib
@@ -27,6 +27,8 @@ defmodule Teiserver.Battle.BalanceLib do
   # which one will get to pick first
   @shuffle_first_pick true
 
+  @default_balance_algorithm "loser_picks"
+
   @spec defaults() :: map()
   def defaults() do
     %{
@@ -38,6 +40,11 @@ defmodule Teiserver.Battle.BalanceLib do
       fuzz_multiplier: @fuzz_multiplier,
       shuffle_first_pick: @shuffle_first_pick
     }
+  end
+
+  defp get_default_algorithm() do
+    # For now it's a constant but this could be moved to a configurable value
+    @default_balance_algorithm
   end
 
   @spec algorithm_modules() :: %{String.t() => module}
@@ -81,6 +88,12 @@ defmodule Teiserver.Battle.BalanceLib do
     mean_diff_max: the maximum difference in mean between the party and paired parties
     stddev_diff_max: the maximum difference in stddev between the party and paired parties
   """
+  @spec create_balance([BT.player_group()], non_neg_integer) :: map
+  def create_balance(groups, team_count) do
+    # This method sets default opts (and makes some warnings go away)
+    create_balance(groups, team_count, [])
+  end
+
   @spec create_balance([BT.player_group()], non_neg_integer, list) :: map
   def create_balance([], _team_count, _opts) do
     %{
@@ -93,7 +106,8 @@ defmodule Teiserver.Battle.BalanceLib do
       team_players: %{},
       team_sizes: %{},
       means: %{},
-      stdevs: %{}
+      stdevs: %{},
+      has_parties?: false
     }
   end
 
@@ -118,6 +132,15 @@ defmodule Teiserver.Battle.BalanceLib do
             end
           end)
 
+        rank_times =
+          Map.values(members)
+          |> Enum.map(fn x ->
+            cond do
+              Map.has_key?(x, :rank_time) -> x.rank_time
+              true -> 0
+            end
+          end)
+
         names =
           members
           |> Enum.map(fn {id, details} ->
@@ -133,15 +156,18 @@ defmodule Teiserver.Battle.BalanceLib do
           ranks: ranks,
           names: names,
           group_rating: Enum.sum(ratings),
-          count: Enum.count(ratings)
+          count: Enum.count(ratings),
+          rank_times: rank_times
         }
       end)
 
+    algo_name = opts[:algorithm] || get_default_algorithm()
+
     # Now we pass this to the algorithm and it does the rest!
     balance_result =
-      case algorithm_modules()[opts[:algorithm] || "loser_picks"] do
+      case algorithm_modules()[algo_name] do
         nil ->
-          raise "No balance module by the name of '#{opts[:algorithm] || "loser_picks"}'"
+          raise "No balance module by the name of '#{algo_name}'"
 
         m ->
           m.perform(expanded_groups, team_count, opts)
@@ -176,7 +202,7 @@ defmodule Teiserver.Battle.BalanceLib do
   defp cleanup_result(result) do
     Map.take(
       result,
-      ~w(team_groups team_players ratings captains team_sizes deviation means stdevs logs)a
+      ~w(team_groups team_players ratings captains team_sizes deviation means stdevs logs has_parties?)a
     )
   end
 
@@ -221,7 +247,8 @@ defmodule Teiserver.Battle.BalanceLib do
 
     Map.merge(balance_result, %{
       team_groups: team_groups,
-      team_players: team_players
+      team_players: team_players,
+      has_parties?: balanced_teams_has_parties?(team_groups)
     })
   end
 
@@ -560,17 +587,10 @@ defmodule Teiserver.Battle.BalanceLib do
     get_user_rating_value(userid, rating_type_id)
   end
 
-  # Used to get the rating value of the user for internal balance purposes which might be
-  # different from public/reporting
   @spec get_user_balance_rating_value(T.userid(), String.t() | non_neg_integer()) ::
           BT.rating_value()
   defp get_user_balance_rating_value(userid, rating_type_id) when is_integer(rating_type_id) do
-    real_rating = get_user_rating_value(userid, rating_type_id)
-
-    stats = Account.get_user_stat_data(userid)
-    adjustment = int_parse(stats["os_global_adjust"])
-
-    real_rating + adjustment
+    get_user_rating_value(userid, rating_type_id)
   end
 
   defp get_user_balance_rating_value(_userid, nil), do: nil
@@ -586,26 +606,39 @@ defmodule Teiserver.Battle.BalanceLib do
 
   def get_user_rating_rank(userid, rating_type, fuzz_multiplier) do
     # This call will go to db or cache
-    # The cache for ratings is :teiserver_user_stat_cache
+    # The cache for ratings is :teiserver_user_ratings
     # which has an expiry of 60s
     # See application.ex for cache settings
     rating_type_id = MatchRatingLib.rating_type_name_lookup()[rating_type]
     rating = get_user_balance_rating_value(userid, rating_type_id)
     rating = fuzz_rating(rating, fuzz_multiplier)
+
+    # Get stats data
+    # Potentially adjust ratings based on os_global_adjust
+    # Also fetch chevron_hours (rank_time)
+    stats = Account.get_user_stat_data(userid)
+    adjustment = int_parse(stats["os_global_adjust"])
+    rating = rating + adjustment
+    rank_time = CacheUser.rank_time(stats)
+
     # This call will go to db or cache
     # The cache for users is :users
     # which is permanent (and would be instantiated on login)
     # See application.ex for cache settings
+
     %{rank: rank, name: name} = Account.get_user_by_id(userid)
-    %{rating: rating, rank: rank, name: name}
+    %{rating: rating, rank: rank, name: name, rank_time: rank_time}
   end
 
   @doc """
   This is used by some screens to calculate a theoretical balance based on old ratings
   """
   def get_user_rating_rank_old(userid, rating_value) do
+    stats = Account.get_user_stat_data(userid)
+    rank_time = CacheUser.rank_time(stats)
+
     %{rank: rank, name: name} = Account.get_user_by_id(userid)
-    %{rating: rating_value, rank: rank, name: name}
+    %{rating: rating_value, rank: rank, name: name, rank_time: rank_time}
   end
 
   defp fuzz_rating(rating, multiplier) do
@@ -836,5 +869,31 @@ defmodule Teiserver.Battle.BalanceLib do
     else
       for(y <- make_combinations(n - x.count, xs), do: [x | y]) ++ make_combinations(n, xs)
     end
+  end
+
+  @doc """
+  Can be called to detect if a balance result has parties
+  If the result has no parties we do not need to check team deviation
+  """
+  def balanced_teams_has_parties?(team_groups) do
+    Enum.reduce_while(team_groups, false, fn {_key, team}, _acc ->
+      case team_has_parties?(team) do
+        true -> {:halt, true}
+        false -> {:cont, false}
+      end
+    end)
+  end
+
+  @spec team_has_parties?([BT.group()]) :: boolean()
+  def team_has_parties?(team) do
+    Enum.reduce_while(team, false, fn x, _acc ->
+      group_count = x[:count]
+
+      if group_count > 1 do
+        {:halt, true}
+      else
+        {:cont, false}
+      end
+    end)
   end
 end

--- a/lib/teiserver/mix_tasks/fake_playtime.ex
+++ b/lib/teiserver/mix_tasks/fake_playtime.ex
@@ -1,0 +1,70 @@
+defmodule Mix.Tasks.Teiserver.FakePlaytime do
+  @moduledoc """
+  Adds fake play time stats to all non bot users
+  Run with
+  mix teiserver.fake_playtime
+  """
+
+  use Mix.Task
+  require Logger
+  alias Teiserver.{Account, CacheUser}
+
+  def run(_args) do
+    Application.ensure_all_started(:teiserver)
+
+    if Application.get_env(:teiserver, Teiserver)[:enable_hailstorm] do
+      Account.list_users(
+        search: [
+          not_has_role: "Bot"
+        ],
+        select: [:id, :name]
+      )
+      |> Enum.map(fn user ->
+        update_stats(user.id, random_playtime())
+      end)
+
+      Logger.info("Finished applying fake playtime data")
+    end
+  end
+
+  def update_stats(user_id, player_minutes) do
+    Account.update_user_stat(user_id, %{
+      player_minutes: player_minutes,
+      total_minutes: player_minutes
+    })
+
+    # Now recalculate ranks
+    # This calc would usually be done in do_login
+    rank = CacheUser.calculate_rank(user_id)
+    user = Teiserver.Account.UserCacheLib.get_user_by_id(user_id)
+
+    user = %{
+      user
+      | rank: rank
+    }
+
+    CacheUser.update_user(user, true)
+  end
+
+  defp random_playtime() do
+    hours =
+      case get_player_experience() do
+        :just_installed -> Enum.random(0..4)
+        :noob -> Enum.random(5..99)
+        :average -> Enum.random(100..249)
+        :pro -> Enum.random(250..1750)
+      end
+
+    hours * 60
+  end
+
+  @spec get_player_experience() :: :just_installed | :noob | :average | :pro
+  defp get_player_experience do
+    case Enum.random(0..3) do
+      0 -> :just_installed
+      1 -> :noob
+      2 -> :average
+      3 -> :pro
+    end
+  end
+end

--- a/lib/teiserver_web/controllers/admin/match_controller.ex
+++ b/lib/teiserver_web/controllers/admin/match_controller.ex
@@ -131,7 +131,9 @@ defmodule TeiserverWeb.Admin.MatchController do
       |> List.flatten()
 
     past_balance =
-      BalanceLib.create_balance(groups, match.team_count, mode: :loser_picks)
+      BalanceLib.create_balance(groups, match.team_count,
+        algorithm: get_analysis_balance_algorithm()
+      )
       |> Map.put(:balance_mode, :grouped)
 
     # What about new balance?
@@ -256,7 +258,14 @@ defmodule TeiserverWeb.Admin.MatchController do
       end)
       |> List.flatten()
 
-    BalanceLib.create_balance(groups, match.team_count, mode: :loser_picks)
+    BalanceLib.create_balance(groups, match.team_count,
+      algorithm: get_analysis_balance_algorithm()
+    )
     |> Map.put(:balance_mode, :grouped)
+  end
+
+  defp get_analysis_balance_algorithm() do
+    # TODO move this from config into a dropdown so it can be selected on this page
+    Application.get_env(:teiserver, Teiserver)[:analysis_balance_algorithm] || "loser_picks"
   end
 end

--- a/test/teiserver/battle/balance_lib_internal_test.exs
+++ b/test/teiserver/battle/balance_lib_internal_test.exs
@@ -21,12 +21,12 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
 
     assert fixed_groups == [
              %{
-               user1.id => %{name: "User_1", rank: 0, rating: 19},
-               user2.id => %{name: "User_2", rank: 0, rating: 20}
+               user1.id => %{name: user1.name, rank: 0, rating: 19, rank_time: 0},
+               user2.id => %{name: user2.name, rank: 0, rating: 20, rank_time: 0}
              },
-             %{user3.id => %{name: "User_3", rank: 0, rating: 18}},
-             %{user4.id => %{name: "User_4", rank: 0, rating: 15}},
-             %{user5.id => %{name: "User_5", rank: 0, rating: 11}}
+             %{user3.id => %{name: user3.name, rank: 0, rating: 18, rank_time: 0}},
+             %{user4.id => %{name: user4.name, rank: 0, rating: 15, rank_time: 0}},
+             %{user5.id => %{name: user5.name, rank: 0, rating: 11, rank_time: 0}}
            ]
 
     # loser_picks algo will hit the databases so let's just test with split_one_chevs
@@ -62,6 +62,59 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
     # loser_picks algo will hit the databases so let's just test with split_one_chevs
     result = BalanceLib.create_balance(groups, 2, algorithm: "split_one_chevs")
     assert result != nil
+  end
+
+  test "does team have parties" do
+    team = [
+      %{count: 2, group_rating: 13, members: [1, 4], ratings: [8, 5]}
+    ]
+
+    assert BalanceLib.team_has_parties?(team)
+
+    team = [
+      %{count: 1, group_rating: 8, members: [2], ratings: [8]}
+    ]
+
+    refute BalanceLib.team_has_parties?(team)
+  end
+
+  test "does team_groups in balance result have parties" do
+    team_groups = %{
+      1 => [
+        %{count: 2, group_rating: 13, members: [1, 4], ratings: [8, 5]}
+      ],
+      2 => [
+        %{count: 1, group_rating: 6, members: [2], ratings: [6]}
+      ]
+    }
+
+    assert BalanceLib.balanced_teams_has_parties?(team_groups)
+
+    team_groups = %{
+      1 => [
+        %{count: 1, group_rating: 8, members: [1], ratings: [8]},
+        %{count: 1, group_rating: 8, members: [2], ratings: [8]}
+      ],
+      2 => [
+        %{count: 1, group_rating: 6, members: [3], ratings: [6]},
+        %{count: 1, group_rating: 8, members: [4], ratings: [8]}
+      ]
+    }
+
+    refute BalanceLib.balanced_teams_has_parties?(team_groups)
+
+    team_groups = %{
+      1 => [
+        %{count: 1, group_rating: 8, members: [1], ratings: [8]},
+        %{count: 1, group_rating: 8, members: [2], ratings: [8]}
+      ],
+      2 => [
+        %{count: 1, group_rating: 13, members: [3], ratings: [6]},
+        %{count: 2, group_rating: 8, members: [4, 5], ratings: [8, 0]}
+      ]
+    }
+
+    assert BalanceLib.balanced_teams_has_parties?(team_groups)
   end
 
   defp create_test_users do

--- a/test/teiserver/battle/balance_lib_test.exs
+++ b/test/teiserver/battle/balance_lib_test.exs
@@ -1,7 +1,7 @@
 defmodule Teiserver.Battle.BalanceLibTest do
   @moduledoc """
-  Can run tests in this file only by
-  mix test test/teiserver/battle/balance_lib_test.exs
+  Can run all balance tests via
+  mix test --only balance_test
   """
   use Teiserver.DataCase, async: true
   @moduletag :balance_test
@@ -20,6 +20,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
         )
 
       assert result != nil
+      refute Map.get(result, :has_parties?)
     end)
   end
 
@@ -38,6 +39,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
         )
 
       assert result != nil
+      refute Map.get(result, :has_parties?)
     end)
   end
 
@@ -59,6 +61,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
         )
 
       assert result != nil
+      refute Map.get(result, :has_parties?)
     end)
   end
 
@@ -80,6 +83,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
         )
 
       assert result != nil
+      refute Map.get(result, :has_parties?)
     end)
   end
 
@@ -103,6 +107,7 @@ defmodule Teiserver.Battle.BalanceLibTest do
         )
 
       assert result != nil
+      refute Map.get(result, :has_parties?)
     end)
   end
 
@@ -139,6 +144,9 @@ defmodule Teiserver.Battle.BalanceLibTest do
         )
 
       assert result != nil
+      # has_parties? might be true/false depending on the algorithm.
+      # Just check that the key exists
+      assert Map.has_key?(result, :has_parties?)
     end)
   end
 end

--- a/test/teiserver/battle/cheeky_switcher_smart_balance_test.exs
+++ b/test/teiserver/battle/cheeky_switcher_smart_balance_test.exs
@@ -1,7 +1,7 @@
 defmodule Teiserver.Battle.CheekySwitcherSmartBalanceTest do
   @moduledoc """
-  Can run tests in this file only by
-  mix test test/teiserver/battle/cheeky_switcher_smart_balance_test.exs
+  Can run all balance tests via
+  mix test --only balance_test
   """
   use Teiserver.DataCase, async: true
   @moduletag :balance_test
@@ -53,7 +53,8 @@ defmodule Teiserver.Battle.CheekySwitcherSmartBalanceTest do
              },
              deviation: 0,
              means: %{1 => 6.5, 2 => 6.5},
-             stdevs: %{1 => 0.5, 2 => 1.5}
+             stdevs: %{1 => 0.5, 2 => 1.5},
+             has_parties?: false
            }
   end
 

--- a/test/teiserver/battle/loser_picks_balance_test.exs
+++ b/test/teiserver/battle/loser_picks_balance_test.exs
@@ -1,7 +1,7 @@
 defmodule Teiserver.Battle.LoserPicksBalanceTest do
   @moduledoc """
-  Can run tests in this file only by
-  mix test test/teiserver/battle/loser_picks_balance_test.exs
+  Can run all balance tests via
+  mix test --only balance_test
   """
   use Teiserver.DataCase, async: true
   @moduletag :balance_test
@@ -52,7 +52,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              },
              deviation: 0,
              means: %{1 => 6.5, 2 => 6.5},
-             stdevs: %{1 => 1.5, 2 => 0.5}
+             stdevs: %{1 => 1.5, 2 => 0.5},
+             has_parties?: false
            }
   end
 
@@ -103,7 +104,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              },
              deviation: 13,
              means: %{1 => 8.0, 2 => 7.0, 3 => 6.0, 4 => 5.0},
-             stdevs: %{1 => 0.0, 2 => 0.0, 3 => 0.0, 4 => 0.0}
+             stdevs: %{1 => 0.0, 2 => 0.0, 3 => 0.0, 4 => 0.0},
+             has_parties?: false
            }
   end
 
@@ -160,7 +162,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              },
              deviation: 0,
              means: %{1 => 7.5, 2 => 7.0, 3 => 7.5},
-             stdevs: %{1 => 1.5, 2 => 2.0, 3 => 0.5}
+             stdevs: %{1 => 1.5, 2 => 2.0, 3 => 0.5},
+             has_parties?: false
            }
   end
 
@@ -209,7 +212,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              },
              deviation: 0,
              means: %{1 => 6.5, 2 => 6.5},
-             stdevs: %{1 => 1.5, 2 => 0.5}
+             stdevs: %{1 => 1.5, 2 => 0.5},
+             has_parties?: true
            }
   end
 
@@ -276,7 +280,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              },
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 20.125, 2 => 20.5},
-             stdevs: %{1 => 9.29297449689818, 2 => 8.671072598012312}
+             stdevs: %{1 => 9.29297449689818, 2 => 8.671072598012312},
+             has_parties?: true
            }
   end
 
@@ -335,7 +340,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              team_players: %{1 => 'ejlnprft', 2 => 'hikmoqsg'},
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 23.0, 2 => 23.0},
-             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736}
+             stdevs: %{1 => 12.816005617976296, 2 => 8.674675786448736},
+             has_parties?: false
            }
   end
 
@@ -394,7 +400,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              },
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 31.0, 2 => 31.625},
-             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046}
+             stdevs: %{1 => 16.015617378046965, 2 => 15.090870584562046},
+             has_parties?: true
            }
 
     result2 =
@@ -453,7 +460,8 @@ defmodule Teiserver.Battle.LoserPicksBalanceTest do
              },
              team_sizes: %{1 => 8, 2 => 8},
              means: %{1 => 31.0, 2 => 31.625},
-             stdevs: %{1 => 16.0312195418814, 2 => 15.074295174236173}
+             stdevs: %{1 => 16.0312195418814, 2 => 15.074295174236173},
+             has_parties?: true
            }
   end
 end

--- a/test/teiserver/battle/provisional_rating_lib_test.exs
+++ b/test/teiserver/battle/provisional_rating_lib_test.exs
@@ -1,0 +1,77 @@
+defmodule Teiserver.Battle.ProvisionalRatingLibTest do
+  use ExUnit.Case
+  @moduletag :balance_test
+  alias Teiserver.Battle.Balance.ProvisionalRatingLib
+
+  test "adjust_rating_from_hours" do
+    ratings = [10, 10, 10, 10, 10, -1]
+    rank_time = [0, 7.5, 20, 3.75, 21, 7.5]
+    result = ProvisionalRatingLib.adjust_rating_from_hours(ratings, rank_time)
+
+    assert result == [0, 5, 10, 2.5, 10, -0.5]
+  end
+
+  test "apply_provisional_ratings" do
+    expanded_group = [
+      %{
+        count: 2,
+        members: ["Pro1", "Noob1"],
+        group_rating: 13,
+        ratings: [8, 5],
+        ranks: [1, 0],
+        names: ["Pro1", "Noob1"],
+        rank_times: [20, 1]
+      },
+      %{
+        count: 1,
+        members: ["Noob2"],
+        group_rating: 6,
+        ratings: [6],
+        ranks: [0],
+        names: ["Noob2"],
+        rank_times: [10]
+      },
+      %{
+        count: 1,
+        members: ["Noob3"],
+        group_rating: 7,
+        ratings: [17],
+        ranks: [0],
+        names: ["Noob3"],
+        rank_times: [10]
+      }
+    ]
+
+    result = ProvisionalRatingLib.apply_provisional_ratings(expanded_group)
+
+    assert result == [
+             %{
+               count: 2,
+               group_rating: 8.333333333333334,
+               members: ["Pro1", "Noob1"],
+               names: ["Pro1", "Noob1"],
+               rank_times: [20, 1],
+               ranks: [1, 0],
+               ratings: [8, 0.3333333333333333]
+             },
+             %{
+               count: 1,
+               group_rating: 4.0,
+               members: ["Noob2"],
+               names: ["Noob2"],
+               rank_times: [10],
+               ranks: [0],
+               ratings: [4.0]
+             },
+             %{
+               count: 1,
+               group_rating: 11.333333333333332,
+               members: ["Noob3"],
+               names: ["Noob3"],
+               rank_times: [10],
+               ranks: [0],
+               ratings: [11.333333333333332]
+             }
+           ]
+  end
+end

--- a/test/teiserver/battle/split_one_chevs_internal_test.exs
+++ b/test/teiserver/battle/split_one_chevs_internal_test.exs
@@ -1,8 +1,8 @@
 defmodule Teiserver.Battle.SplitOneChevsInternalTest do
   @moduledoc """
   This tests the internal functions of SplitOneChevs
-  Can run tests in this file only by
-  mix test test/teiserver/battle/split_one_chevs_internal_test.exs
+  Can run all balance tests via
+  mix test --only balance_test
   """
   use ExUnit.Case
   @moduletag :balance_test
@@ -16,7 +16,8 @@ defmodule Teiserver.Battle.SplitOneChevsInternalTest do
         group_rating: 13,
         ratings: [8, 5],
         ranks: [1, 0],
-        names: ["Pro1", "Noob1"]
+        names: ["Pro1", "Noob1"],
+        rank_times: [15, 1]
       },
       %{
         count: 1,
@@ -24,7 +25,8 @@ defmodule Teiserver.Battle.SplitOneChevsInternalTest do
         group_rating: 6,
         ratings: [6],
         ranks: [0],
-        names: ["Noob2"]
+        names: ["Noob2"],
+        rank_times: [1]
       },
       %{
         count: 1,
@@ -32,7 +34,8 @@ defmodule Teiserver.Battle.SplitOneChevsInternalTest do
         group_rating: 7,
         ratings: [17],
         ranks: [0],
-        names: ["Noob3"]
+        names: ["Noob3"],
+        rank_times: [1]
       }
     ]
 
@@ -40,12 +43,22 @@ defmodule Teiserver.Battle.SplitOneChevsInternalTest do
 
     assert result.team_groups == %{
              1 => [
-               %{count: 1, group_rating: 6, members: ["Noob2"], ratings: [6]},
+               %{
+                 count: 1,
+                 group_rating: 0.3333333333333333,
+                 members: ["Noob1"],
+                 ratings: [0.3333333333333333]
+               },
                %{count: 1, group_rating: 8, members: ["Pro1"], ratings: [8]}
              ],
              2 => [
-               %{count: 1, group_rating: 5, members: ["Noob1"], ratings: [5]},
-               %{count: 1, group_rating: 17, members: ["Noob3"], ratings: [17]}
+               %{count: 1, group_rating: 0.4, members: ["Noob2"], ratings: [0.4]},
+               %{
+                 count: 1,
+                 group_rating: 1.1333333333333333,
+                 members: ["Noob3"],
+                 ratings: [1.1333333333333333]
+               }
              ]
            }
   end

--- a/test/teiserver/battle/split_one_chevs_test.exs
+++ b/test/teiserver/battle/split_one_chevs_test.exs
@@ -1,7 +1,7 @@
 defmodule Teiserver.Battle.SplitOneChevsTest do
   @moduledoc """
-  Can run tests in this file only by
-  mix test test/teiserver/battle/split_one_chevs_test.exs
+  Can run all balance tests via
+  mix test --only balance_test
   """
   use ExUnit.Case
   @moduletag :balance_test
@@ -28,7 +28,8 @@ defmodule Teiserver.Battle.SplitOneChevsTest do
              team_players: %{},
              team_sizes: %{},
              means: %{},
-             stdevs: %{}
+             stdevs: %{},
+             has_parties?: false
            }
   end
 
@@ -36,10 +37,10 @@ defmodule Teiserver.Battle.SplitOneChevsTest do
     result =
       BalanceLib.create_balance(
         [
-          %{1 => %{rating: 5}},
-          %{2 => %{rating: 6}},
-          %{3 => %{rating: 7}},
-          %{4 => %{rating: 8}}
+          %{1 => %{rating: 5, rank_time: 15}},
+          %{2 => %{rating: 6, rank_time: 15}},
+          %{3 => %{rating: 7, rank_time: 15}},
+          %{4 => %{rating: 8, rank_time: 15}}
         ],
         4,
         algorithm: @split_algo
@@ -52,12 +53,12 @@ defmodule Teiserver.Battle.SplitOneChevsTest do
     result =
       BalanceLib.create_balance(
         [
-          %{1 => %{rating: 5}},
-          %{2 => %{rating: 6}},
-          %{3 => %{rating: 7}},
-          %{4 => %{rating: 8}},
-          %{5 => %{rating: 9}},
-          %{6 => %{rating: 9}}
+          %{1 => %{rating: 5, rank_time: 15}},
+          %{2 => %{rating: 6, rank_time: 15}},
+          %{3 => %{rating: 7, rank_time: 15}},
+          %{4 => %{rating: 8, rank_time: 15}},
+          %{5 => %{rating: 9, rank_time: 15}},
+          %{6 => %{rating: 9, rank_time: 15}}
         ],
         3,
         algorithm: @split_algo
@@ -70,9 +71,9 @@ defmodule Teiserver.Battle.SplitOneChevsTest do
     result =
       BalanceLib.create_balance(
         [
-          %{4 => %{rating: 5}, 1 => %{rating: 8}},
-          %{2 => %{rating: 6}},
-          %{3 => %{rating: 7}}
+          %{4 => %{rating: 5, rank_time: 15}, 1 => %{rating: 8, rank_time: 15}},
+          %{2 => %{rating: 6, rank_time: 15}},
+          %{3 => %{rating: 7, rank_time: 15}}
         ],
         2,
         rating_lower_boundary: 100,
@@ -89,21 +90,24 @@ defmodule Teiserver.Battle.SplitOneChevsTest do
     result =
       BalanceLib.create_balance(
         [
-          %{"Pro1" => %{rating: 5, rank: 1}},
-          %{"Pro2" => %{rating: 6, rank: 1}},
-          %{"Noob1" => %{rating: 7, rank: 0}},
-          %{"Noob2" => %{rating: 8, rank: 0}}
+          %{"Pro1" => %{rating: 5, rank: 1, rank_time: 15}},
+          %{"Pro2" => %{rating: 6, rank: 1, rank_time: 15}},
+          %{"Noob1" => %{rating: 7, rank: 0, rank_time: 1}},
+          %{"Noob2" => %{rating: 8, rank: 0, rank_time: 1}}
         ],
         4,
         algorithm: @split_algo
       )
 
     assert result.logs == [
-             "Begin split_one_chevs balance",
-             "Pro2 (Chev: 2) picked for Team 1",
-             "Pro1 (Chev: 2) picked for Team 2",
-             "Noob2 (Chev: 1) picked for Team 3",
-             "Noob1 (Chev: 1) picked for Team 4"
+             "Algorithm: split_one_chevs",
+             "---------------------------",
+             "Your team will try and avoid picking one chevs and prefer picking players with higher Adjusted Rating. Adjusted Rating starts at 0 and converges towards OS over time. Once a player hits three chevrons, Adjusted Rating just equals OS.",
+             "---------------------------",
+             "Pro2 (6, Chev: 2) picked for Team 1",
+             "Pro1 (5, Chev: 2) picked for Team 2",
+             "Noob2 (0.5, Chev: 1) picked for Team 3",
+             "Noob1 (0.5, Chev: 1) picked for Team 4"
            ]
   end
 
@@ -111,21 +115,24 @@ defmodule Teiserver.Battle.SplitOneChevsTest do
     result =
       BalanceLib.create_balance(
         [
-          %{"Pro1" => %{rating: 5, rank: 1}},
-          %{"Pro2" => %{rating: 6, rank: 1}},
-          %{"Noob1" => %{rating: 7, rank: 0}},
-          %{"Noob2" => %{rating: 8, rank: 0}}
+          %{"Pro1" => %{rating: 5, rank: 1, rank_time: 15}},
+          %{"Pro2" => %{rating: 6, rank: 1, rank_time: 15}},
+          %{"Noob1" => %{rating: 7, rank: 0, rank_time: 1}},
+          %{"Noob2" => %{rating: 8, rank: 0, rank_time: 1}}
         ],
         2,
         algorithm: @split_algo
       )
 
     assert result.logs == [
-             "Begin split_one_chevs balance",
-             "Pro2 (Chev: 2) picked for Team 1",
-             "Pro1 (Chev: 2) picked for Team 2",
-             "Noob2 (Chev: 1) picked for Team 2",
-             "Noob1 (Chev: 1) picked for Team 1"
+             "Algorithm: split_one_chevs",
+             "---------------------------",
+             "Your team will try and avoid picking one chevs and prefer picking players with higher Adjusted Rating. Adjusted Rating starts at 0 and converges towards OS over time. Once a player hits three chevrons, Adjusted Rating just equals OS.",
+             "---------------------------",
+             "Pro2 (6, Chev: 2) picked for Team 1",
+             "Pro1 (5, Chev: 2) picked for Team 2",
+             "Noob2 (0.5, Chev: 1) picked for Team 2",
+             "Noob1 (0.5, Chev: 1) picked for Team 1"
            ]
   end
 end

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -1,0 +1,19 @@
+defmodule Teiserver.Game.BalancerServerTest do
+  @moduledoc false
+  use ExUnit.Case
+  @moduletag :balance_test
+  alias Teiserver.Game.BalancerServer
+
+  test "get fuzz multiplier" do
+    result = BalancerServer.get_fuzz_multiplier([])
+    assert result == 0
+
+    result = BalancerServer.get_fuzz_multiplier(algorithm: "loser_picks", fuzz_multiplier: 0.5)
+    assert result == 0.5
+
+    result =
+      BalancerServer.get_fuzz_multiplier(algorithm: "split_one_chevs", fuzz_multiplier: 0.5)
+
+    assert result == 0
+  end
+end


### PR DESCRIPTION
## Context
I played a game with split_one_chevs on and noticed a few issues. The 1Chevs were not split. This was because Macwhite was recognised by Teiserver as a 2Chev whereas Chobby showed them as a 1Chev. This is likely because Chobby gets a player's rank on login and then never updates it so they get out of sync with TeiServer.
![3](https://github.com/jauggy/teiserver/assets/1305569/a0c700a7-516c-47fc-9017-cb2f49cc9109)
![2](https://github.com/jauggy/teiserver/assets/1305569/1c0c432f-b7ca-4e70-8246-8bb24108f8c4)

## How to resolve?
To resolve this my algorithm will now group both 1 and 2Chevs into the "Noob" bucket. There's also going to be slight change on how we draft players who are in the "Noob" bucket detailed below.

### Other Findings
When putting the replay
```
https://www.beyondallreason.info/replays?gameId=39096966518c40a66b2130b057864aa5
```
into https://openskill-test.web.app/ I noticed that the library expects Team 1 to win, despite that most humans would bet on Team 2. 

![4](https://github.com/jauggy/teiserver/assets/1305569/c1498bce-3e39-46f3-bb00-ff431392eb06)

Since the library expects Team 1 to win, if my team were to win I would gain a lot of OS i.e. +1. If my team were to lose, I only lose -0.37.

From this we can conclude that if you were to choose from the three "Noobs": _CindersFire, Macwhite, Victorious_Dead_ you probably want to avoid the overrated players, which are likely the ones with highest uncertainty. If an overrated player is on the other team, you stand to win more and lose less, and since they're overrated, you're also more likely to win. Therefore, for those in the "Noobs" category, we probably want to pick those with low uncertainty as they are less likely to be overrated.

## split_one_chevs Algorithm v2
Based on these findings, the algorithm will now draft players based on these criteria:
1. Always pick experienced (3Chev+) players over noobs (1-2Chevs).
2. Prefer higher OS for experienced players.
3. Prefer lower uncertainty for noobs.

This draft mimics how a human might draft players with the given visible information in a lobby. It's not super mathematical. Players generally look at chevron level to determine how overrated someone might be.

## Further enchancements
Previously, if the balancer was called it would check the result and if the deviation in ratings between teams was too high, it would rerun the balancer but split all parties into solo players. Now the balance result will have a new field: `has_parties?`. If this is false we do not need to rerun the balancer again.

## Known Bugs
Teiserver doesn't know the rank shown to the user in Chobby. Chobby gets the rank on login and then never updates. Teiserver, therefore, may classify a user as 2Chev but they might be shown as 1Chev in Chobby.

## Unit Tests
Run this to run multiple unit tests that relate to balance
```
  mix test --only balance_test
```

## Local Dev Tests
If your db doesn't have the small/team large team split you will need to rerun the fake data task:
```
mix teiserver.fakedata
```
The create fake data task made by Teifion doesn't give fake users any playtime stats. So we need to add them:
```
mix teiserver.fake_playtime
```
Launch the website
```
mix phx.server
```
Now go to Admin > Matches > Select a Match > Balance Tab.
You will see the logs for the `loser_picks` algo. 

Now go to `config/dev.exs` and change the `analysis_balance_algorithm` to use `split_one_chevs`.
Launch the website. Now go to Admin > Matches > Select a Match > Balance Tab.
You will see the logs for the `split_one_chevs` algo.

## Theoretical Testing on past replays
Go here: https://balance-algo-web.web.app/
And enter a past replay. Change algorithm to Split One Chevs v2